### PR TITLE
Add layout component

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface LayoutProps {
+  children: React.ReactNode;
+  showFooter?: boolean;
+}
+
+const Layout: React.FC<LayoutProps> = ({ children, showFooter = false }) => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <header className="bg-white shadow-md p-4 flex items-center">
+        <img src="/vite.svg" alt="logo" className="h-8 w-8 mr-2" />
+        <span className="text-2xl font-bold text-purple-600">Rayito</span>
+      </header>
+      <main className="flex-1">{children}</main>
+      {showFooter && (
+        <footer className="bg-gray-100 text-center text-gray-500 p-4 text-sm">
+          © 2024 Rayito
+        </footer>
+      )}
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import Layout from './components/Layout';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Layout showFooter>
+      <App />
+    </Layout>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `Layout` component for a shared header and optional footer
- wrap the application in the new layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cdf10a75c832c99884d1ad968b48d