### PR TITLE
Agregar MateriaCard

### DIFF
--- a/src/components/MateriaCard.tsx
+++ b/src/components/MateriaCard.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface MateriaCardProps {
+  icon: string;
+  name: string;
+  completed?: boolean;
+}
+
+const MateriaCard: React.FC<MateriaCardProps> = ({ icon, name, completed = false }) => {
+  const statusText = completed ? 'Completa' : 'En curso';
+  const statusColor = completed ? 'bg-green-100 text-green-600' : 'bg-blue-100 text-blue-600';
+
+  return (
+    <div className="bg-white rounded-2xl p-4 shadow-md flex items-center space-x-3">
+      <div className="text-2xl">
+        {icon}
+      </div>
+      <div className="flex-1">
+        <h3 className="font-semibold text-gray-800">{name}</h3>
+      </div>
+      <span className={`text-sm font-medium px-2 py-1 rounded-lg ${statusColor}`}>{statusText}</span>
+    </div>
+  );
+};
+
+export default MateriaCard;


### PR DESCRIPTION
## Summary
- crear `MateriaCard` para mostrar una materia con icono, nombre y estado

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ce141b8e4832c8a8a1b77dd436888