### PR TITLE
Add new ActividadSimple component

### DIFF
--- a/src/components/ActividadSimple.tsx
+++ b/src/components/ActividadSimple.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface ActividadSimpleProps {
+  texto: string;
+  opciones: string[];
+  onSelect?: (opcion: string) => void;
+}
+
+const ActividadSimple: React.FC<ActividadSimpleProps> = ({ texto, opciones, onSelect }) => {
+  return (
+    <div className="bg-white rounded-3xl p-6 shadow-lg space-y-4">
+      <p className="text-lg font-medium text-gray-800">{texto}</p>
+      <div className="grid gap-3">
+        {opciones.map((opcion, index) => (
+          <button
+            key={index}
+            onClick={() => onSelect?.(opcion)}
+            className="w-full bg-blue-500 text-white rounded-xl py-2 px-4 hover:bg-blue-600 transition-colors"
+          >
+            {opcion}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ActividadSimple;


### PR DESCRIPTION
## Summary
- introduce `ActividadSimple` component for simple quiz-style activities

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ce1473c40832cb3c361cfaaf07787